### PR TITLE
chore: add StringSyntax annotations to JSON properties and parameters

### DIFF
--- a/src/PQSoft.JsonComparer.AwesomeAssertions/JsonComparisonAssertions.cs
+++ b/src/PQSoft.JsonComparer.AwesomeAssertions/JsonComparisonAssertions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using AwesomeAssertions;
 
@@ -6,8 +7,9 @@ namespace PQSoft.JsonComparer.AwesomeAssertions;
 /// <summary>
 /// A simple wrapper around a JSON string that serves as the subject for JSON-specific assertions.
 /// </summary>
-public class JsonSubject(string json)
+public class JsonSubject([StringSyntax(StringSyntaxAttribute.Json)] string json)
 {
+    [StringSyntax(StringSyntaxAttribute.Json)]
     public string Json { get; } = json ?? throw new ArgumentNullException(nameof(json));
 }
 
@@ -32,7 +34,10 @@ public class JsonSubjectAssertions(JsonSubject subject)
     /// <param name="expectedJson">The expected JSON string.</param>
     /// <param name="because">An optional reason message to include in the failure.</param>
     /// <param name="becauseArgs">Optional parameters for the reason message.</param>
-    public JsonSubjectAssertions FullyMatch(string expectedJson, string because = "", params object[] becauseArgs)
+    public JsonSubjectAssertions FullyMatch(
+        [StringSyntax(StringSyntaxAttribute.Json)] string expectedJson,
+        string because = "",
+        params object[] becauseArgs)
     {
         var result = JsonComparer.ExactMatch(expectedJson, subject.Json, out Dictionary<string, JsonElement> extractedValues, out List<string> mismatches);
         ExtractedValues = extractedValues;
@@ -53,7 +58,10 @@ public class JsonSubjectAssertions(JsonSubject subject)
     /// <param name="expectedJson">The expected JSON subset.</param>
     /// <param name="because">An optional reason message to include in the failure.</param>
     /// <param name="becauseArgs">Optional parameters for the reason message.</param>
-    public JsonSubjectAssertions ContainSubset(string expectedJson, string because = "", params object[] becauseArgs)
+    public JsonSubjectAssertions ContainSubset(
+        [StringSyntax(StringSyntaxAttribute.Json)] string expectedJson,
+        string because = "",
+        params object[] becauseArgs)
     {
         var result = JsonComparer.SubsetMatch(expectedJson, subject.Json, out Dictionary<string, JsonElement> extractedValues, out List<string> mismatches);
         ExtractedValues = extractedValues;
@@ -76,7 +84,7 @@ public static class JsonSubjectExtensions
     /// <summary>
     /// Wraps the JSON string in a <see cref="JsonSubject"/>.
     /// </summary>
-    public static JsonSubject AsJsonString(this string json)
+    public static JsonSubject AsJsonString([StringSyntax(StringSyntaxAttribute.Json)] this string json)
     {
         return new JsonSubject(json);
     }

--- a/src/PQSoft.JsonComparer/JsonComparer.cs
+++ b/src/PQSoft.JsonComparer/JsonComparer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using PQSoft.JsonComparer.Functions;
@@ -61,8 +62,11 @@ public static partial class JsonComparer
     /// Returns true if they match exactly (except for tokens), false otherwise.
     /// Also extracts any token values (e.g. JOBID) into extractedValues and records mismatch details.
     /// </summary>
-    public static bool ExactMatch(string expectedJson, string actualJson,
-        out Dictionary<string, JsonElement> extractedValues, out List<string> mismatches)
+    public static bool ExactMatch(
+        [StringSyntax(StringSyntaxAttribute.Json)] string expectedJson,
+        [StringSyntax(StringSyntaxAttribute.Json)] string actualJson,
+        out Dictionary<string, JsonElement> extractedValues,
+        out List<string> mismatches)
     {
         return Compare(expectedJson, actualJson, subsetMode: false, out extractedValues, out mismatches);
     }
@@ -73,7 +77,9 @@ public static partial class JsonComparer
     /// Also extracts any token values (e.g. JOBID) into extractedValues and records mismatch details.
     /// </summary>
     public static async Task<(bool IsMatch, Dictionary<string, JsonElement> ExtractedValues, List<string> Mismatches)> ExactMatchAsync(
-        string expectedJson, string actualJson, CancellationToken cancellationToken = default)
+        [StringSyntax(StringSyntaxAttribute.Json)] string expectedJson,
+        [StringSyntax(StringSyntaxAttribute.Json)] string actualJson,
+        CancellationToken cancellationToken = default)
     {
         return await CompareAsync(expectedJson, actualJson, subsetMode: false, null, cancellationToken);
     }
@@ -83,7 +89,10 @@ public static partial class JsonComparer
     /// Returns true if they match exactly (except for tokens), false otherwise.
     /// Also extracts any token values (e.g. JOBID) into extractedValues and records mismatch details.
     /// </summary>
-    public static bool ExactMatch(string expectedJson, string actualJson, TimeProvider timeProvider,
+    public static bool ExactMatch(
+        [StringSyntax(StringSyntaxAttribute.Json)] string expectedJson,
+        [StringSyntax(StringSyntaxAttribute.Json)] string actualJson,
+        TimeProvider timeProvider,
         out Dictionary<string, JsonElement> extractedValues, out List<string> mismatches)
     {
         return Compare(expectedJson, actualJson, subsetMode: false, timeProvider, out extractedValues, out mismatches);
@@ -95,7 +104,10 @@ public static partial class JsonComparer
     /// Also extracts any token values (e.g. JOBID) into extractedValues and records mismatch details.
     /// </summary>
     public static async Task<(bool IsMatch, Dictionary<string, JsonElement> ExtractedValues, List<string> Mismatches)> ExactMatchAsync(
-        string expectedJson, string actualJson, TimeProvider timeProvider, CancellationToken cancellationToken = default)
+        [StringSyntax(StringSyntaxAttribute.Json)] string expectedJson,
+        [StringSyntax(StringSyntaxAttribute.Json)] string actualJson,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken = default)
     {
         return await CompareAsync(expectedJson, actualJson, subsetMode: false, timeProvider, cancellationToken);
     }
@@ -105,8 +117,11 @@ public static partial class JsonComparer
     /// Returns true if all elements in expected (except tokens) are found in actual.
     /// Also extracts any token values into extractedValues and records mismatch details.
     /// </summary>
-    public static bool SubsetMatch(string expectedJson, string actualJson,
-        out Dictionary<string, JsonElement> extractedValues, out List<string> mismatches)
+    public static bool SubsetMatch(
+        [StringSyntax(StringSyntaxAttribute.Json)] string expectedJson,
+        [StringSyntax(StringSyntaxAttribute.Json)] string actualJson,
+        out Dictionary<string, JsonElement> extractedValues,
+        out List<string> mismatches)
     {
         return Compare(expectedJson, actualJson, subsetMode: true, out extractedValues, out mismatches);
     }
@@ -117,7 +132,9 @@ public static partial class JsonComparer
     /// Also extracts any token values into extractedValues and records mismatch details.
     /// </summary>
     public static async Task<(bool IsMatch, Dictionary<string, JsonElement> ExtractedValues, List<string> Mismatches)> SubsetMatchAsync(
-        string expectedJson, string actualJson, CancellationToken cancellationToken = default)
+        [StringSyntax(StringSyntaxAttribute.Json)] string expectedJson,
+        [StringSyntax(StringSyntaxAttribute.Json)] string actualJson,
+        CancellationToken cancellationToken = default)
     {
         return await CompareAsync(expectedJson, actualJson, subsetMode: true, null, cancellationToken);
     }
@@ -127,8 +144,12 @@ public static partial class JsonComparer
     /// Returns true if all elements in expected (except tokens) are found in actual.
     /// Also extracts any token values into extractedValues and records mismatch details.
     /// </summary>
-    public static bool SubsetMatch(string expectedJson, string actualJson, TimeProvider timeProvider,
-        out Dictionary<string, JsonElement> extractedValues, out List<string> mismatches)
+    public static bool SubsetMatch(
+        [StringSyntax(StringSyntaxAttribute.Json)] string expectedJson,
+        [StringSyntax(StringSyntaxAttribute.Json)] string actualJson,
+        TimeProvider timeProvider,
+        out Dictionary<string, JsonElement> extractedValues,
+        out List<string> mismatches)
     {
         return Compare(expectedJson, actualJson, subsetMode: true, timeProvider, out extractedValues, out mismatches);
     }
@@ -139,7 +160,10 @@ public static partial class JsonComparer
     /// Also extracts any token values into extractedValues and records mismatch details.
     /// </summary>
     public static async Task<(bool IsMatch, Dictionary<string, JsonElement> ExtractedValues, List<string> Mismatches)> SubsetMatchAsync(
-        string expectedJson, string actualJson, TimeProvider timeProvider, CancellationToken cancellationToken = default)
+        [StringSyntax(StringSyntaxAttribute.Json)] string expectedJson,
+        [StringSyntax(StringSyntaxAttribute.Json)] string actualJson,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken = default)
     {
         return await CompareAsync(expectedJson, actualJson, subsetMode: true, timeProvider, cancellationToken);
     }
@@ -148,8 +172,12 @@ public static partial class JsonComparer
     /// Parses the JSON strings and calls the recursive CompareElements function.
     /// It pre-processes the expected JSON string by executing functions and wrapping unquoted tokens with quotes.
     /// </summary>
-    private static bool Compare(string expectedJson, string actualJson, bool subsetMode,
-        out Dictionary<string, JsonElement> extractedValues, out List<string> mismatches)
+    private static bool Compare(
+        [StringSyntax(StringSyntaxAttribute.Json)] string expectedJson,
+        [StringSyntax(StringSyntaxAttribute.Json)] string actualJson,
+        bool subsetMode,
+        out Dictionary<string, JsonElement> extractedValues,
+        out List<string> mismatches)
     {
         return Compare(expectedJson, actualJson, subsetMode, null, out extractedValues, out mismatches);
     }
@@ -158,8 +186,13 @@ public static partial class JsonComparer
     /// Parses the JSON strings and calls the recursive CompareElements function.
     /// It pre-processes the expected JSON string by executing functions and wrapping unquoted tokens with quotes.
     /// </summary>
-    private static bool Compare(string expectedJson, string actualJson, bool subsetMode, TimeProvider? timeProvider,
-        out Dictionary<string, JsonElement> extractedValues, out List<string> mismatches)
+    private static bool Compare(
+        [StringSyntax(StringSyntaxAttribute.Json)] string expectedJson,
+        [StringSyntax(StringSyntaxAttribute.Json)] string actualJson,
+        bool subsetMode,
+        TimeProvider? timeProvider,
+        out Dictionary<string, JsonElement> extractedValues,
+        out List<string> mismatches)
     {
         extractedValues = [];
         mismatches = [];
@@ -184,7 +217,11 @@ public static partial class JsonComparer
     /// It pre-processes the expected JSON string by executing functions and wrapping unquoted tokens with quotes.
     /// </summary>
     private static async Task<(bool IsMatch, Dictionary<string, JsonElement> ExtractedValues, List<string> Mismatches)> CompareAsync(
-        string expectedJson, string actualJson, bool subsetMode, TimeProvider? timeProvider, CancellationToken cancellationToken)
+        [StringSyntax(StringSyntaxAttribute.Json)] string expectedJson,
+        [StringSyntax(StringSyntaxAttribute.Json)] string actualJson,
+        bool subsetMode,
+        TimeProvider? timeProvider,
+        CancellationToken cancellationToken)
     {
         var extractedValues = new Dictionary<string, JsonElement>();
         var mismatches = new List<string>();
@@ -346,7 +383,7 @@ public static partial class JsonComparer
     /// <param name="json">The JSON string containing function calls to process.</param>
     /// <param name="timeProvider">Optional TimeProvider for time-based functions.</param>
     /// <returns>The JSON string with function calls replaced by their execution results.</returns>
-    private static string ProcessFunctions(string json, TimeProvider? timeProvider = null)
+    private static string ProcessFunctions([StringSyntax(StringSyntaxAttribute.Json)] string json, TimeProvider? timeProvider = null)
     {
         var registry = timeProvider != null ? new JsonFunctionRegistry(timeProvider) : FunctionRegistry;
 


### PR DESCRIPTION
The [StringSyntax](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.stringsyntaxattribute?view=net-9.0) annotation provides IDEs with information about the content of string literals and in this case highlight invalid JSON syntax in string literals at the call site.

<img width="611" height="172" alt="image" src="https://github.com/user-attachments/assets/26bba9dc-03ca-4039-bc8a-e593c4295cef" />